### PR TITLE
docs: add need help section after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ pnpm dlx convex env set AUTH_GITHUB_SECRET your-github-client-secret
 
 **NOTE:** Please make sure to keep your API keys and configuration values secure and do not expose them publicly.
 
+### :raising_hand: Need Help?
+
+If you run into issues during installation or setup:
+
+- **GitHub Discussions** — [Open a Q&A discussion](https://github.com/sanidhyy/slack-clone/discussions/new?category=q-a) for setup and troubleshooting help.
+- **Email** — [sanidhyyy@gmail.com](mailto:sanidhyyy@gmail.com)
+- **Discord** — `sanidhyy`
+
 ## :camera: Screenshots
 
 ![Sign in and Sign up form using Convex Auth](/.github/images/img1.png 'Sign in and Sign up form using Convex Auth')

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ If you run into issues during installation or setup:
 
 - **GitHub Discussions** — [Open a Q&A discussion](https://github.com/sanidhyy/slack-clone/discussions/new?category=q-a) for setup and troubleshooting help.
 - **Email** — [sanidhyyy@gmail.com](mailto:sanidhyyy@gmail.com)
-- **Discord** — `sanidhyy`
+- **Discord** — `@sanidhyy`
 
 ## :camera: Screenshots
 


### PR DESCRIPTION
## Summary
- Adds a **Need Help?** section after the installation/setup instructions
- Includes GitHub Discussions (Q&A), email, and Discord contact options

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm help section appears after setup instructions
