### PR TITLE
fix: disable vercel image optimization to save resources

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: { unoptimized: true },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Set `images.unoptimized` to `true` in Next.js config so `next/image` serves original sources instead of Vercel Image Optimization to save resources.